### PR TITLE
2019/sprint#6/fix_xml_dom_error_output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@democracy-deutschland/scapacra",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Scapacra (Scraper Parser Crawler)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/evaluator/DocumentEvaluator.ts
+++ b/src/evaluator/DocumentEvaluator.ts
@@ -27,10 +27,35 @@ namespace Documents_Evaluator {
             this.readableStream = readableStream;
         }
 
+        protected xmlDOMErrorCallback(msg: String): void {
+            console.log(`[xmldom error]: ${msg}`);
+        }
+        protected xmlDOMFatalErrorCallback(msg: String): void {
+            console.log(`[xmldom error]: ${msg}`);
+        }
+        protected xmlDOMWarningCallback(msg: String): void {
+            console.log(`[xmldom warning]: ${msg}`);
+        }
+
+
         public async evaluate(xPathExpression: string): Promise<any[]> {
             let xml = await this.removeXmlHeader(this.readableStream);
 
-            let parser = new DOMParser();
+            let parser = new DOMParser({
+                /**
+                 * locator is always need for error position info
+                 */
+                locator: {},
+                /**
+                 * you can override the errorHandler for xml parser
+                 * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
+                 */
+                errorHandler: {
+                    warning: this.xmlDOMWarningCallback,
+                    error: this.xmlDOMErrorCallback,
+                    fatalError: this.xmlDOMFatalErrorCallback
+                }
+            });
             let doc = parser.parseFromString(xml);
 
             let nodes = xpath.select(xPathExpression, doc);
@@ -53,7 +78,7 @@ namespace Documents_Evaluator {
                         reject(err);
                     }
                 });
-            });       
+            });
         }
 
         /**


### PR DESCRIPTION
allow custom error handlers on xmldom parsing

already published as 1.0.3